### PR TITLE
Give user name instead of ID for minute-taker drawn from < 3 people

### DIFF
--- a/src/dana/commands/meetings.py
+++ b/src/dana/commands/meetings.py
@@ -64,7 +64,7 @@ class Meeting:
     def takes_minutes(self):
         """Pick a participant taking minutes"""
         if len(self.participants) < 3:
-            return [np.random.choice(list(self.participants.values()))] * 3
+            return [np.random.choice(list(self.participants.keys()))] * 3
 
         p = np.asarray(list(self.participants.keys()))
         w = np.asarray(self.weight)


### PR DESCRIPTION
I set up a meeting with only two participants, and the bot tells us a numeric user ID to take minutes instead of an @ mention. I think this should fix it.